### PR TITLE
compiler/cpp -> compiler/cxx

### DIFF
--- a/external_metadata/frozenlist.toml
+++ b/external_metadata/frozenlist.toml
@@ -1,5 +1,5 @@
 [external]
 build-requires = [
   "dep:virtual/compiler/c",
-  "dep:virtual/compiler/cpp",
+  "dep:virtual/compiler/cxx",
 ]

--- a/external_metadata/greenlet.toml
+++ b/external_metadata/greenlet.toml
@@ -1,5 +1,5 @@
 [external]
 build-requires = [
   "dep:virtual/compiler/c",
-  "dep:virtual/compiler/cpp",
+  "dep:virtual/compiler/cxx",
 ]

--- a/external_metadata/grpcio-tools.toml
+++ b/external_metadata/grpcio-tools.toml
@@ -1,5 +1,5 @@
 [external]
 build-requires = [
   "dep:virtual/compiler/c",
-  "dep:virtual/compiler/cpp",
+  "dep:virtual/compiler/cxx",
 ]

--- a/external_metadata/grpcio.toml
+++ b/external_metadata/grpcio.toml
@@ -1,7 +1,7 @@
 [external]
 build-requires = [
   "dep:virtual/compiler/c",
-  "dep:virtual/compiler/cpp",
+  "dep:virtual/compiler/cxx",
 ]
 
 # Note that there are quite a few optional dependencies, but they aren't used

--- a/external_metadata/kiwisolver.toml
+++ b/external_metadata/kiwisolver.toml
@@ -1,4 +1,4 @@
 [external]
 build-requires = [
-  "dep:virtual/compiler/cpp",
+  "dep:virtual/compiler/cxx",
 ]

--- a/external_metadata/matplotlib.toml
+++ b/external_metadata/matplotlib.toml
@@ -1,7 +1,7 @@
 [external]
 build-requires = [
   "dep:virtual/compiler/c",
-  "dep:virtual/compiler/cpp",
+  "dep:virtual/compiler/cxx",
   "dep:generic/make",
   "dep:generic/pkg-config",
 ]

--- a/external_metadata/msgpack.toml
+++ b/external_metadata/msgpack.toml
@@ -1,5 +1,5 @@
 [external]
 build-requires = [
   "dep:virtual/compiler/c",
-  "dep:virtual/compiler/cpp",
+  "dep:virtual/compiler/cxx",
 ]

--- a/external_metadata/numpy.toml
+++ b/external_metadata/numpy.toml
@@ -1,7 +1,7 @@
 [external]
 build-requires = [
   "dep:virtual/compiler/c",
-  "dep:virtual/compiler/cpp",
+  "dep:virtual/compiler/cxx",
   "dep:virtual/compiler/fortran",
   "dep:generic/ninja",
   "dep:generic/pkg-config",

--- a/external_metadata/pandas.toml
+++ b/external_metadata/pandas.toml
@@ -1,6 +1,6 @@
 [external]
 build-requires = [
   "dep:virtual/compiler/c",
-  "dep:virtual/compiler/cpp",
+  "dep:virtual/compiler/cxx",
   "dep:generic/ninja",
 ]

--- a/external_metadata/pyarrow.toml
+++ b/external_metadata/pyarrow.toml
@@ -1,7 +1,7 @@
 [external]
 build-requires = [
   "dep:virtual/compiler/c",
-  "dep:virtual/compiler/cpp",
+  "dep:virtual/compiler/cxx",
   "dep:generic/cmake",
   "dep:generic/clang",
 ]

--- a/external_metadata/scikit-learn.toml
+++ b/external_metadata/scikit-learn.toml
@@ -1,5 +1,5 @@
 [external]
 build-requires = [
   "dep:virtual/compiler/c",
-  "dep:virtual/compiler/cpp",
+  "dep:virtual/compiler/cxx",
 ]

--- a/external_metadata/scipy.toml
+++ b/external_metadata/scipy.toml
@@ -1,7 +1,7 @@
 [external]
 build-requires = [
   "dep:virtual/compiler/c",
-  "dep:virtual/compiler/cpp",
+  "dep:virtual/compiler/cxx",
   "dep:virtual/compiler/fortran",
   "dep:generic/ninja",
   "dep:generic/pkg-config",


### PR DESCRIPTION
As per changes in https://github.com/jaimergp/external-metadata-mappings/pull/10, C++ is now referred to as `cxx`.