### PR TITLE
Use pyproject-external from PyPI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-https://github.com/jaimergp/pyproject-external/archive/main.tar.gz
+pyproject-external


### PR DESCRIPTION
Thanks to https://github.com/jaimergp/pyproject-external/pull/29, https://github.com/jaimergp/pyproject-external/releases/tag/0.1.0, and https://pypi.org/project/pyproject-external/0.1.0/, we don't need the github tarball anymore.