### PR TITLE
Add CI builds for Ubuntu

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -56,7 +56,7 @@ jobs:
           elif [[ ${{ matrix.platform[1] }} == "Ubuntu" ]]; then
             apt update
             apt upgrade -y
-            apt install -y sudo python3 python-is-python3
+            apt install -y sudo python3 python-is-python3 python3-venv
           elif [[ ${{ matrix.platform[1] }} == "conda-forge" ]]; then
             "${SHELL}" <(curl -L micro.mamba.pm/install.sh)
             source ~/.bashrc
@@ -184,7 +184,7 @@ jobs:
           elif [[ ${{ matrix.platform[1] }} == "Ubuntu" ]]; then
             sudo apt update
             sudo apt upgrade
-            sudo apt install python3 python-is-python3
+            sudo apt install python3 python-is-python3 python3-venv
           elif [[ ${{ matrix.platform[1] }} == "conda-forge" ]]; then
             "${SHELL}" <(curl -L micro.mamba.pm/install.sh)
             source ~/.bashrc

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -220,6 +220,9 @@ jobs:
       - name: Build from sdist
         if: ${{ matrix.platform[2] }}
         run: |
+          if [[ ${{ matrix.platform[1] }} == "Ubuntu" ]]; then
+            sudo apt -f install  # fix libjpeg absence?
+          fi
           if [[ ${{ matrix.platform[1] }} == "conda-forge" ]]; then
             source ~/.bashrc && micromamba activate cfenv
           else

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -54,9 +54,9 @@ jobs:
           elif [[ ${{ matrix.platform[1] }} == "Arch" ]]; then
             pacman -Syu python sudo --noconfirm # will install 3.11
           elif [[ ${{ matrix.platform[1] }} == "Ubuntu" ]]; then
-            sudo apt update
-            sudo apt upgrade
-            sudo apt install python3  
+            apt update
+            apt upgrade
+            apt install sudo python3  
           elif [[ ${{ matrix.platform[1] }} == "conda-forge" ]]; then
             "${SHELL}" <(curl -L micro.mamba.pm/install.sh)
             source ~/.bashrc

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -38,11 +38,11 @@ jobs:
           # - ["archlinux:latest", "Arch"]
           # - ["fedora:40", "Fedora"]
           # - ["archlinux:latest", "conda-forge"]
-          - ["", "Ubuntu"]
+          - ["ubuntu:24.04", "Ubuntu"]
         pkgdata:
           - [cryptography, cryptography]
     runs-on: ubuntu-latest
-    container: ${{ matrix.platform[0] && matrix.platform[0] || null }}
+    container: ${{ matrix.platform[0] }}
     name: ${{ matrix.pkgdata[0] }}, ${{ matrix.platform[1] }}
     steps:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
@@ -125,7 +125,7 @@ jobs:
           # - ["archlinux:latest", "Arch", true]
           # - ["fedora:40", "Fedora", true]
           # - ["archlinux:latest", "conda-forge", true]
-          - ["", "Ubuntu", true]
+          - ["ubuntu:24.04", "Ubuntu", true]
         pkgdata:
           # [package-name (must be normalized with lowercase and only dashes), import-name]
           - [cryptography, cryptography]
@@ -166,7 +166,7 @@ jobs:
           - [pycryptodomex, Cryptodome]
           - [google-crc32c, google_crc32c]
     runs-on: ubuntu-latest
-    container: ${{ matrix.platform[0] && matrix.platform[0] || null }}
+    container: ${{ matrix.platform[0] }}
     name: ${{ matrix.pkgdata[0] }}, ${{ matrix.platform[1] }}, ${{ matrix.platform[2] }}
     steps:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
@@ -220,9 +220,6 @@ jobs:
       - name: Build from sdist
         if: ${{ matrix.platform[2] }}
         run: |
-          if [[ ${{ matrix.platform[1] }} == "Ubuntu" ]]; then
-            sudo apt -f install  # fix libjpeg absence?
-          fi
           if [[ ${{ matrix.platform[1] }} == "conda-forge" ]]; then
             source ~/.bashrc && micromamba activate cfenv
           else

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -182,9 +182,9 @@ jobs:
           elif [[ ${{ matrix.platform[1] }} == "Arch" ]]; then
             pacman -Syu python sudo --noconfirm # will install 3.11
           elif [[ ${{ matrix.platform[1] }} == "Ubuntu" ]]; then
-            sudo apt update
-            sudo apt upgrade
-            sudo apt install python3 python-is-python3 python3-venv
+            apt update
+            apt upgrade -y
+            apt install -y sudo python3 python-is-python3 python3-venv
           elif [[ ${{ matrix.platform[1] }} == "conda-forge" ]]; then
             "${SHELL}" <(curl -L micro.mamba.pm/install.sh)
             source ~/.bashrc

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -53,6 +53,10 @@ jobs:
             sudo dnf install -y python  # will install 3.12
           elif [[ ${{ matrix.platform[1] }} == "Arch" ]]; then
             pacman -Syu python sudo --noconfirm # will install 3.11
+          elif [[ ${{ matrix.platform[1] }} == "Ubuntu" ]]; then
+            sudo apt update
+            sudo apt upgrade
+            sudo apt install python3  
           elif [[ ${{ matrix.platform[1] }} == "conda-forge" ]]; then
             "${SHELL}" <(curl -L micro.mamba.pm/install.sh)
             source ~/.bashrc
@@ -177,6 +181,10 @@ jobs:
             sudo dnf install -y python  # will install 3.12
           elif [[ ${{ matrix.platform[1] }} == "Arch" ]]; then
             pacman -Syu python sudo --noconfirm # will install 3.11
+          elif [[ ${{ matrix.platform[1] }} == "Ubuntu" ]]; then
+            sudo apt update
+            sudo apt upgrade
+            sudo apt install python3
           elif [[ ${{ matrix.platform[1] }} == "conda-forge" ]]; then
             "${SHELL}" <(curl -L micro.mamba.pm/install.sh)
             source ~/.bashrc

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -55,8 +55,8 @@ jobs:
             pacman -Syu python sudo --noconfirm # will install 3.11
           elif [[ ${{ matrix.platform[1] }} == "Ubuntu" ]]; then
             apt update
-            apt upgrade
-            apt install sudo python3  
+            apt upgrade -y
+            apt install -y sudo python3  
           elif [[ ${{ matrix.platform[1] }} == "conda-forge" ]]; then
             "${SHELL}" <(curl -L micro.mamba.pm/install.sh)
             source ~/.bashrc

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -35,13 +35,14 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - ["archlinux:latest", "Arch"]
-          - ["fedora:40", "Fedora"]
-          - ["archlinux:latest", "conda-forge"]
+          # - ["archlinux:latest", "Arch"]
+          # - ["fedora:40", "Fedora"]
+          # - ["archlinux:latest", "conda-forge"]
+          - ["", "Ubuntu"]
         pkgdata:
           - [cryptography, cryptography]
-    runs-on: ubuntu-22.04
-    container: ${{ matrix.platform[0] }}
+    runs-on: ubuntu-latest
+    container: ${{ matrix.platform[0] && matrix.platform[0] || null }}
     name: ${{ matrix.pkgdata[0] }}, ${{ matrix.platform[1] }}
     steps:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
@@ -121,9 +122,10 @@ jobs:
           # use-external=false will have a lot of failures; only uncomment if
           # you're interested in seeing what the current baseline is.
           #- ["archlinux:latest", "Arch", false]  # baseline
-          - ["archlinux:latest", "Arch", true]
-          - ["fedora:40", "Fedora", true]
-          - ["archlinux:latest", "conda-forge", true]
+          # - ["archlinux:latest", "Arch", true]
+          # - ["fedora:40", "Fedora", true]
+          # - ["archlinux:latest", "conda-forge", true]
+          - ["", "Ubuntu", true]
         pkgdata:
           # [package-name (must be normalized with lowercase and only dashes), import-name]
           - [cryptography, cryptography]
@@ -163,8 +165,8 @@ jobs:
           - [grpcio-tools, grpc]
           - [pycryptodomex, Cryptodome]
           - [google-crc32c, google_crc32c]
-    runs-on: ubuntu-22.04
-    container: ${{ matrix.platform[0] }}
+    runs-on: ubuntu-latest
+    container: ${{ matrix.platform[0] && matrix.platform[0] || null }}
     name: ${{ matrix.pkgdata[0] }}, ${{ matrix.platform[1] }}, ${{ matrix.platform[2] }}
     steps:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -35,9 +35,9 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          # - ["archlinux:latest", "Arch"]
-          # - ["fedora:40", "Fedora"]
-          # - ["archlinux:latest", "conda-forge"]
+          - ["archlinux:latest", "Arch"]
+          - ["fedora:40", "Fedora"]
+          - ["archlinux:latest", "conda-forge"]
           - ["ubuntu:24.04", "Ubuntu"]
         pkgdata:
           - [cryptography, cryptography]
@@ -126,9 +126,9 @@ jobs:
           # use-external=false will have a lot of failures; only uncomment if
           # you're interested in seeing what the current baseline is.
           #- ["archlinux:latest", "Arch", false]  # baseline
-          # - ["archlinux:latest", "Arch", true]
-          # - ["fedora:40", "Fedora", true]
-          # - ["archlinux:latest", "conda-forge", true]
+          - ["archlinux:latest", "Arch", true]
+          - ["fedora:40", "Fedora", true]
+          - ["archlinux:latest", "conda-forge", true]
           - ["ubuntu:24.04", "Ubuntu", true]
         pkgdata:
           # [package-name (must be normalized with lowercase and only dashes), import-name]

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -56,7 +56,7 @@ jobs:
           elif [[ ${{ matrix.platform[1] }} == "Ubuntu" ]]; then
             apt update
             apt upgrade -y
-            apt install -y sudo python3  
+            apt install -y sudo python3 python-is-python3
           elif [[ ${{ matrix.platform[1] }} == "conda-forge" ]]; then
             "${SHELL}" <(curl -L micro.mamba.pm/install.sh)
             source ~/.bashrc
@@ -184,7 +184,7 @@ jobs:
           elif [[ ${{ matrix.platform[1] }} == "Ubuntu" ]]; then
             sudo apt update
             sudo apt upgrade
-            sudo apt install python3
+            sudo apt install python3 python-is-python3
           elif [[ ${{ matrix.platform[1] }} == "conda-forge" ]]; then
             "${SHELL}" <(curl -L micro.mamba.pm/install.sh)
             source ~/.bashrc


### PR DESCRIPTION
Uses `ubuntu:24.04` image (instead of the default GHA runner) to start with a minimal system. The GHA runner has a lot of things pre-installed which would allow some builds to pass with a faulty mapping or `[external]` table (e.g. Python headers, `cargo`, etc).