### PR TITLE
Debug bcrypt x ubuntu

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -35,12 +35,12 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - ["archlinux:latest", "Arch"]
-          - ["fedora:42", "Fedora"]
-          - ["archlinux:latest", "conda-forge"]
+          # - ["archlinux:latest", "Arch"]
+          # - ["fedora:42", "Fedora"]
+          # - ["archlinux:latest", "conda-forge"]
           - ["ubuntu:24.04", "Ubuntu"]
         pkgdata:
-          - [cryptography, cryptography]
+          - [bcrypt, bcrypt]
     runs-on: ubuntu-latest
     container: ${{ matrix.platform[0] }}
     name: ${{ matrix.pkgdata[0] }}, ${{ matrix.platform[1] }}
@@ -117,7 +117,8 @@ jobs:
 
   with_external_metadata:
     needs: smoketest
-    if: github.repository == 'rgommers/external-deps-build'
+    if: false
+    # github.repository == 'rgommers/external-deps-build'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
We need to choose between mapping `dep:virtual/compiler/rust` to either `["rustc", "cargo"]` (this is v1.74 in Ubuntu 24.04) or `["rustc-1.82", "cargo-1.82"]`. No solution works for both `bcrypt` and `rpds-py`.

So we are stuck between:

- Installing `rustc` (1.75):
  - Makes `rpds-py` fail because `rustc` is found in PATH and it is too old for `rpds-py`'s lockfile.
  - Makes `bcrypt` pass because this `rustc` version is good enough for this package.
- Installing `rustc-1.82` (or not installing anything at all).
  - `rpds-py` would pass because there would be no `rustc` in PATH and the fallback auto-install would kick in.
  - `bcrypt` would fail because there's no `rustc` in PATH.

If only there was a package in Ubuntu that symlinked `rustc` to `rustc-1.82`, just like `python-is-python3`...